### PR TITLE
Move Mongoose to a peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "shared Database models between platform microservices.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Mongoose uses an internal global cache of data for schemas etc. A consumer of this package will make the connection to MongoDB using the version of Mongoose installed in the parent package. Move Mongoose to a peer dependency so this package and its package use the same Mongoose package.

Also add Mongoose as a dev dependency for local development. Dev dependencies are not installed when this package is required by another.