### PR TITLE
#163523283 Connection identity keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Connection model maps to a MongoDB collection and defines the shape of the docum
 * [Connection](#Connection) : <code>object</code>
     * [~userId](#Connection..userId) : <code>String</code>
     * [~accessKey](#Connection..accessKey) : <code>String</code>
+    * [~sourceIdentityKey](#Connection..sourceIdentityKey) : <code>String</code>
+    * [~targetIdentityKey](#Connection..targetIdentityKey) : <code>String</code>
     * [~status](#Connection..status) : <code>String</code>
 
 <a name="Connection..userId"></a>
@@ -324,6 +326,18 @@ Unique identifier for each connection.
 
 **Kind**: inner property of [<code>Connection</code>](#Connection)
 **Required**:
+<a name="Connection..sourceIdentityKey"></a>
+
+### Connection~sourceIdentityKey : <code>String</code>
+Source Identity Key for each connection.
+
+**Kind**: inner property of [<code>Connection</code>](#Connection)
+<a name="Connection..targetIdentityKey"></a>
+
+### Connection~targetIdentityKey : <code>String</code>
+Target Identity Key for each connection.
+
+**Kind**: inner property of [<code>Connection</code>](#Connection)
 <a name="Connection..status"></a>
 
 ### Connection~status : <code>String</code>

--- a/lib/platform/connection.js
+++ b/lib/platform/connection.js
@@ -44,6 +44,32 @@ const schema = schemaCreator.createSchema(
       type: String,
       required: true,
     },
+    /**
+     * @name sourceIdentityKey
+     * @desc The sourceIdentityKey of each connection.
+     * @type String
+     * @memberof Connection
+     * @unique
+     * @inner
+     */
+    sourceIdentityKey: {
+      // TODO: make it required when accessKey is removed
+      type: String,
+      unique: true,
+    },
+    /**
+     * @name targetIdentityKey
+     * @desc The targetIdentityKey of each connection.
+     * @type String
+     * @memberof Connection
+     * @unique
+     * @inner
+     */
+    targetIdentityKey: {
+      // TODO: make it required when accessKey is removed
+      type: String,
+      unique: true,
+    },
   },
   {
     versionKey: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "shared Database models between platform microservices.",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/platform/connection.spec.js
+++ b/tests/unit/platform/connection.spec.js
@@ -23,6 +23,8 @@ describe('Connection Schema Validation', () => {
       userId: 'myUserId',
       accessKey: 'myKey',
       status: 'myStatus',
+      sourceIdentityKey: 'sourceIdentityKey',
+      targetIdentityKey: 'targetIdentityKey',
     };
     Connection = new ConnectionModel(connectionObject);
     error = Connection.validateSync();


### PR DESCRIPTION
- Extended Connection model to support sourceIdentityKey and targetIdentityKey
- Both properties are not required for the moment and can be null, until accessKey is completely removed