### PR TITLE
Add sparse to identity keys

### DIFF
--- a/lib/platform/connection.js
+++ b/lib/platform/connection.js
@@ -56,6 +56,7 @@ const schema = schemaCreator.createSchema(
       // TODO: make it required when accessKey is removed
       type: String,
       unique: true,
+      sparse: true,
     },
     /**
      * @name targetIdentityKey
@@ -69,6 +70,7 @@ const schema = schemaCreator.createSchema(
       // TODO: make it required when accessKey is removed
       type: String,
       unique: true,
+      sparse: true,
     },
   },
   {


### PR DESCRIPTION
With only `unique: true`, it failed when there are multiple documents with `null` as sourceIdentityKey (targetIdentityKey). So `sparse: true` ensures unique values, but allowing multiple docs without the field.

ref. https://docs.mongodb.com/manual/core/index-sparse/

Will be removed when the fields are going to be required.