### PR TITLE
[#165767540] - Remove unique constraint in wallet collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,7 +911,6 @@ The user identifier.
 
 **Kind**: inner property of [<code>Wallet</code>](#Wallet)  
 **Required**:   
-**Unique**:   
 <a name="Wallet..ethAddress"></a>
 
 ### Wallet~ethAddress : <code>String</code>

--- a/lib/platform/wallet.js
+++ b/lib/platform/wallet.js
@@ -28,13 +28,11 @@ const schema = schemaCreator.createSchema(
      * @type String
      * @memberof Wallet
      * @required
-     * @unique
      * @inner
      */
     userId: {
       type: String,
       required: true,
-      unique: true,
     },
     /**
      * @name ethAddress

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "shared Database models between platform microservices.",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/platform/wallet.spec.js
+++ b/tests/unit/platform/wallet.spec.js
@@ -100,7 +100,6 @@ describe('Wallet Schema Validation', () => {
     const firstCall = getMockFirstCall(schemaCreator.createSchema);
 
     expect(firstCall.publicKey).toHaveProperty('unique', true);
-    expect(firstCall.userId).toHaveProperty('unique', true);
     expect(firstCall.ethAddress).toHaveProperty('unique', true);
   });
 


### PR DESCRIPTION
Change to remove unique constraint for userId in Wallet collection. We need to register more than one wallet for a specific user.