### PR TITLE
Add recovery property to wallet model

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ Wallet model maps to a MongoDB collection and defines the shape of the document.
     * [~blocknativeRegistered](#Wallet..blocknativeRegistered) : <code>Boolean</code>
     * [~type](#Wallet..tpye) : <code>String</code>
     * [~disabled](#Wallet..disabled) : <code>Boolean</code>
+    * [~recovery](#Wallet..recovery) : <code>Boolean</code>
 
 <a name="Wallet..publicKey"></a>
 
@@ -1042,6 +1043,13 @@ The type of the wallet. KEY_BASED or SMART_WALLET
 
 ### Wallet~disabled : <code>Disabled</code>
 A flag indicating if the wallet is disabled or not.
+
+**Kind**: inner property of [<code>Wallet</code>](#Wallet)
+**Required**:
+<a name="Wallet..recovery"></a>
+
+### Wallet~recovery : <code>Recovery</code>
+A flag indicating if the wallet is recovery wallet or not.
 
 **Kind**: inner property of [<code>Wallet</code>](#Wallet)
 **Required**:

--- a/lib/platform/wallet.js
+++ b/lib/platform/wallet.js
@@ -105,6 +105,19 @@ const schema = schemaCreator.createSchema(
       required: true,
       default: false,
     },
+    /**
+     * @name recovery
+     * @desc A flag indicating if the wallet is recovery wallet or not.
+     * @type Boolean
+     * @memberof Wallet
+     * @required
+     * @inner
+     */
+    recovery: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
   },
   {
     versionKey: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.33.0",
+  "version": "1.35.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4608,7 +4608,7 @@
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
@@ -5885,7 +5885,7 @@
     },
     "regexp-clone": {
       "version": "0.0.1",
-      "resolved": "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=",
       "dev": true
     },
@@ -6568,7 +6568,7 @@
     },
     "sliced": {
       "version": "1.0.1",
-      "resolved": "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/sliced/-/sliced-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
     },
@@ -6762,7 +6762,7 @@
     },
     "sparse-bitfield": {
       "version": "3.0.3",
-      "resolved": "https://pillarproject.jfrog.io/pillarproject/api/npm/npm/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "dev": true,
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/common-models",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "shared Database models between platform microservices.",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/platform/wallet.spec.js
+++ b/tests/unit/platform/wallet.spec.js
@@ -120,6 +120,7 @@ describe('Wallet Schema Validation', () => {
       fcmToken: 'fcmId',
       bcxRegistered: false,
       disabled: 'wrongType',
+      recovery: false,
     };
     wallet = new WalletModel(walletObject);
     error = wallet.validateSync();
@@ -127,6 +128,24 @@ describe('Wallet Schema Validation', () => {
     expect(wallet.validateSync).toThrow();
     expect(error.errors.disabled.message).toEqual(
       'Cast to Boolean failed for value "wrongType" at path "disabled"',
+    );
+  });
+
+  it('should be invalid when recovery field is not Boolean.', () => {
+    walletObject = {
+      userId: 'myUserId',
+      publicKey: 'myKey',
+      ethAddress: 'myEthAddress',
+      fcmToken: 'fcmId',
+      bcxRegistered: false,
+      recovery: 'wrongType',
+    };
+    wallet = new WalletModel(walletObject);
+    error = wallet.validateSync();
+
+    expect(wallet.validateSync).toThrow();
+    expect(error.errors.recovery.message).toEqual(
+      'Cast to Boolean failed for value "wrongType" at path "recovery"',
     );
   });
 


### PR DESCRIPTION
Added `recovery` property to Wallet model to track whether a wallet is recovery wallet and send information to analytics service.